### PR TITLE
Only add compiler arguments for GCC and CLang

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -314,16 +314,17 @@ add_library(${ANTLR4_CPP_RUNTIME} ${ANTLR4_CPP_RUNTIME_SRC})
 target_include_directories(${ANTLR4_CPP_RUNTIME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
-    target_compile_options(${ANTLR4_CPP_RUNTIME} PRIVATE
-        -g -Wall -O0
-    )
-else()
-    target_compile_options(${ANTLR4_CPP_RUNTIME} PRIVATE
-        -w -O3
-    )
-    target_compile_options(${ANTLR4_CPP_RUNTIME} PUBLIC
-        -Wno-attributes
-    )
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+	if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
+		target_compile_options(${ANTLR4_CPP_RUNTIME} PRIVATE
+			-g -Wall -O0
+		)
+	else()
+		target_compile_options(${ANTLR4_CPP_RUNTIME} PRIVATE
+			-w -O3
+		)
+		target_compile_options(${ANTLR4_CPP_RUNTIME} PUBLIC
+			-Wno-attributes
+		)
+	endif()
 endif()


### PR DESCRIPTION
I'm using this from Windows and the compiler arguments are not valid for MSVC